### PR TITLE
Add unit toggle feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <h1>WeatherNow</h1>
     <input type="text" id="city" placeholder="Enter city name..." />
     <button onclick="getWeather()">Get Weather</button>
+    <button onclick="toggleUnit()">Toggle Unit (°C/°F)</button>
     
     <div id="result" class="weather-result">
       <!-- Weather data will appear here -->

--- a/script.js
+++ b/script.js
@@ -1,6 +1,9 @@
+let isCelsius = true;
 async function getWeather() {
     const city = document.getElementById("city").value;
     const apiKey = "fb0e21595ff6125c4aed21ef4fba3225"; // Replace with your real API key
+    const unit = useCelsius ? "metric" :"imperial";
+    const symbol=useCelsius ? "°C" :"°F";
     const url = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=metric`;
   
     const response = await fetch(url);
@@ -14,5 +17,13 @@ async function getWeather() {
       `;
     } else {
       document.getElementById("result").innerHTML = `<p>City not found.</p>`;
+    }
+  }
+
+  function toggleUnit(){
+    useCelsius = !useCelsius;
+    const city = document.getElementById("city").value;
+    if(city){
+        getWeather();
     }
   }

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+
 let isCelsius = true; // Default is Celsius
 
 // Function to get weather

--- a/script.js
+++ b/script.js
@@ -1,29 +1,45 @@
-let isCelsius = true;
+let isCelsius = true; // Default is Celsius
+
+// Function to get weather
 async function getWeather() {
-    const city = document.getElementById("city").value;
-    const apiKey = "fb0e21595ff6125c4aed21ef4fba3225"; // Replace with your real API key
-    const unit = useCelsius ? "metric" :"imperial";
-    const symbol=useCelsius ? "°C" :"°F";
-    const url = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=metric`;
-  
+  const city = document.getElementById("city").value;
+  const apiKey = "fb0e21595ff6125c4aed21ef4fba3225"; // Replace with your real API key
+  const unit = isCelsius ? "metric" : "imperial"; // 'metric' for Celsius, 'imperial' for Fahrenheit
+  const symbol = isCelsius ? "°C" : "°F"; // °C for Celsius, °F for Fahrenheit
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=${unit}`;
+
+  try {
     const response = await fetch(url);
     const data = await response.json();
-  
+
+    // Check if the API request was successful
     if (data.cod === 200) {
       document.getElementById("result").innerHTML = `
         <p><strong>${data.name}, ${data.sys.country}</strong></p>
-        <p>Temp: ${data.main.temp} °C</p>
+        <p>Temp: ${data.main.temp} ${symbol}</p>
         <p>Condition: ${data.weather[0].description}</p>
       `;
     } else {
       document.getElementById("result").innerHTML = `<p>City not found.</p>`;
     }
+  } catch (error) {
+    document.getElementById("result").innerHTML = `<p>Error fetching data.</p>`;
   }
+}
 
-  function toggleUnit(){
-    useCelsius = !useCelsius;
-    const city = document.getElementById("city").value;
-    if(city){
-        getWeather();
-    }
+// Function to toggle between Celsius and Fahrenheit
+function toggleUnit() {
+  isCelsius = !isCelsius; // Toggle the unit (true -> Celsius, false -> Fahrenheit)
+  console.log("Unit toggled:", isCelsius ? "Celsius" : "Fahrenheit"); // Debugging log
+
+  const city = document.getElementById("city").value;
+
+  // Only fetch weather data if a city has been entered
+  if (city) {
+    // Clear any existing weather data before re-fetching
+    document.getElementById("result").innerHTML = "";
+
+    // Fetch weather again with the new unit
+    getWeather();
   }
+}


### PR DESCRIPTION
This pull request adds the ability to toggle between Celsius and Fahrenheit in the weather app. 
- Introduced a `toggleUnit()` function
- Added logic to switch between metric and imperial units based on user selection
- Updated `getWeather()` to use dynamic unit and symbol